### PR TITLE
Addition of an episodes-list page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,9 @@ npm-debug.log
 # secrets files as long as you replace their contents by environment
 # variables.
 /config/*.secret.exs
+
+# Ignore pre-commit hooks
+.pre-commit-config.yaml
+
+# Ignore ASDF files
+.tool-versions

--- a/assets/css/app.css.scss
+++ b/assets/css/app.css.scss
@@ -53,26 +53,65 @@ section {
   margin-top: 15px;
   margin-bottom: 15px;
   border-radius: 5px;
-  padding: 5px;
+  padding: .5em;
 }
 
 .episode {
   display: flex;
+  flex-flow: row wrap;
 
   .link {
     flex: 1;
-    margin-right: 10px;
+    flex-basis: 40%;
   }
 
   .description {
     flex: 1;
+    flex-basis: 58%;
   }
 
 }
 
+.episode-item {
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: space-between;
+  margin-bottom: 2em;
+
+  .title {
+    width: 100%;
+  }
+
+  .description {
+    flex: 1;
+    flex-basis: 60%;
+  }
+
+  .links {
+    flex: 1;
+    flex-basis: 5%;
+
+    div {
+      display: flex;
+      flex-flow: row wrap;
+      justify-content: center;
+
+      a {
+        flex: 1;
+        font-size: 3em;
+        width: 2em;
+        text-align: center;
+      }
+    }
+  }
+}
+
 
 .listen {
-  padding-top: 5px;
+  text-align: center;
+  padding-top: 1em;
+  margin: .5em 0 0 0;
+  border-top: 1px solid #FFF;
 }
 
 .bg-pink {
@@ -107,6 +146,7 @@ section {
 .footer {
   display: flex;
   justify-content: center;
+  margin-bottom: 5em;
 }
 
 body {
@@ -127,4 +167,12 @@ a {
   a {
     color: $et-purple;
   }
+}
+
+.centered {
+  text-align: center;
+}
+
+strong {
+  font-weight: 600;
 }

--- a/lib/elixir_talk_web/controllers/page_controller.ex
+++ b/lib/elixir_talk_web/controllers/page_controller.ex
@@ -8,4 +8,11 @@ defmodule ElixirTalkWeb.PageController do
 
     render conn, "index.html", %{track: latest_track}
   end
+
+  def episodes(conn, _params) do
+    {:ok, %{body: body}} = HTTPoison.get("http://feeds.soundcloud.com/users/soundcloud:users:334579745/sounds.rss")
+    {:ok, parsed} = ElixirFeedParser.parse(body)
+
+    render conn, "entries.html", episodes: parsed.entries
+  end
 end

--- a/lib/elixir_talk_web/router.ex
+++ b/lib/elixir_talk_web/router.ex
@@ -17,6 +17,7 @@ defmodule ElixirTalkWeb.Router do
     pipe_through :browser # Use the default browser stack
 
     get "/", PageController, :index
+    get "/episodes", PageController, :episodes
   end
 
   # Other scopes may use custom stacks.

--- a/lib/elixir_talk_web/templates/layout/app.html.eex
+++ b/lib/elixir_talk_web/templates/layout/app.html.eex
@@ -24,12 +24,22 @@
 
     <title>The ElixirTalk Podcast</title>
     <link rel="stylesheet" href="<%= static_path(@conn, "/css/app.css") %>">
-    <script defer src="https://use.fontawesome.com/releases/v5.0.8/js/all.js" integrity="sha384-SlE991lGASHoBfWbelyBPLsUlwY1GwNDJo3jSJO04KZ33K2bwfV9YBauFfnzvynJ" crossorigin="anonymous"></script>
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.4.1/css/all.css" integrity="sha384-5sAR7xN1Nv6T6+dT2mhtzEpVJvfS3NScPQTrOxhwjIuvcA67KV2R5Jz6kr4abQsz" crossorigin="anonymous">
   </head>
 
   <body>
     <div class="container">
       <main role="main">
+        <div class="header">
+          <div class="headline">
+            <div class="logo">
+              <img src=<%= static_path(@conn, "/images/logo.png") %> width="100px">
+            </div>
+            <h1>The ElixirTalk Podcast</h1>
+          </div>
+          <p>Taking questions from around the Elixir community about application design principles and the state of the ecosystem. <a href="https://github.com/elixirtalk/elixirtalk/issues" target="_blank">Ask us a question</a>! </p>
+        </div>
+
         <%= render @view_module, @view_template, assigns %>
       </main>
 

--- a/lib/elixir_talk_web/templates/page/entries.html.eex
+++ b/lib/elixir_talk_web/templates/page/entries.html.eex
@@ -1,0 +1,29 @@
+<section class="episode-list">
+  <%= for episode <- @episodes do %>
+    <div class="episode-item">
+      <div class="title">
+        <h3><%= episode.title %></h3>
+      </div>
+      <div class="description">
+        <%= description(episode) %>
+      </div>
+      <div class="links">
+        <div>
+          <a href="<%= episode.url %>"
+             title="View this episode on SoundCloud"
+             class="soundcloud"
+             target="_blank"
+             rel="noopener"><i class="fab fa-soundcloud"></i></a>
+          <a href="https://itunes.apple.com/us/podcast/elixirtalk/id1298287048"
+             title="View this episode in iTunes"
+             class="itunes"
+             target="_blank"
+             rel="noopener"><i class="fab fa-itunes"></i></a>
+        </div>
+      </div>
+    </div>
+  <% end %>
+</section>
+<section>
+  <p class="centered"><a href="/">Back to the home page</a></p>
+</section>

--- a/lib/elixir_talk_web/templates/page/index.html.eex
+++ b/lib/elixir_talk_web/templates/page/index.html.eex
@@ -1,28 +1,16 @@
-<div class="header">
-  <div class="headline">
-    <div class="logo">
-      <img src=<%= static_path(@conn, "/images/logo.png") %> width="100px">
-    </div>
-    <h1>The ElixirTalk Podcast</h1>
-  </div>
-  <p>Taking questions from around the Elixir community about application design principles and the state of the ecosystem. <a href="https://github.com/elixirtalk/elixirtalk/issues" target="_blank">Ask us a question</a>! </p>
-</div>
-
 <section class="latest-episode bg-pink">
-  <h3>Latest Episode</h3>
+  <h3>Latest Episode: <%= @track.title %> (<%= created(@track) %>)</h3>
   <div class="episode">
-    <div class="link">
-      <iframe width="100%" height="166" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/<%= id(@track) %>&color=%23ff5500&auto_play=false&hide_related=true&show_comments=false&show_user=true&show_reposts=false&show_teaser=false"></iframe>
-    </div>
     <div class="description">
-      <p>
-        <%= created(@track) %> - <%= description(@track) %>
-      </p>
+      <%= description(@track) %>
+    </div>
+    <div class="link">
+      <iframe width="440" height="166" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/<%= id(@track) %>&color=%23ff5500&auto_play=false&hide_related=true&show_comments=false&show_user=true&show_reposts=false&show_teaser=false"></iframe>
     </div>
   </div>
   <div class="listen">
     <p>
-    Listen to all episodes on <a href="https://itunes.apple.com/us/podcast/elixirtalk/id1298287048?mt=2" target="_blank">iTunes</a> or our <a href="https://soundcloud.com/elixirtalk" target="_blank">SoundCloud page</a>.
+      You can view and listen to past episodes on our <a href="/episodes">listing page</a>, our <a href="https://soundcloud.com/elixirtalk" target="_blank">SoundCloud page</a>, or on <a href="https://itunes.apple.com/us/podcast/elixirtalk/id1298287048?mt=2" target="_blank">iTunes</a>.
     </p>
   </div>
 </section>

--- a/lib/elixir_talk_web/views/page_view.ex
+++ b/lib/elixir_talk_web/views/page_view.ex
@@ -9,12 +9,17 @@ defmodule ElixirTalkWeb.PageView do
 
   def description(%{description: description}) do
     description
-    |> String.replace("\n", "</p><p>")
+    |> replace_links
+    |> Earmark.as_html!
     |> raw()
   end
 
   def created(%{updated: date}) do
     Timex.format!(date, "{Mfull} {D}, {YYYY}")
+  end
+
+  def replace_links(text) do
+    Regex.replace(~r/\b((https?|ftp):\/\/[^\s]+)\b/, text, "[\\1](\\1)")
   end
 
 end

--- a/mix.exs
+++ b/mix.exs
@@ -41,8 +41,9 @@ defmodule ElixirTalk.Mixfile do
       {:gettext, "~> 0.11"},
       {:cowboy, "~> 1.0"},
       {:timex, "~> 3.3", override: true},
+      {:earmark, "~> 1.2"},
       {:distillery, "~> 1.5"},
-      {:edeliver, "~> 1.4"}
+      {:edeliver, "~> 1.4"},
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,9 +1,9 @@
-%{
-  "certifi": {:hex, :certifi, "2.3.1", "d0f424232390bf47d82da8478022301c561cf6445b5b5fb6a84d49a9e76d2639", [:rebar3], [{:parse_trans, "3.2.0", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
+%{"certifi": {:hex, :certifi, "2.3.1", "d0f424232390bf47d82da8478022301c561cf6445b5b5fb6a84d49a9e76d2639", [:rebar3], [{:parse_trans, "3.2.0", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
   "combine": {:hex, :combine, "0.10.0", "eff8224eeb56498a2af13011d142c5e7997a80c8f5b97c499f84c841032e429f", [:mix], [], "hexpm"},
   "cowboy": {:hex, :cowboy, "1.1.2", "61ac29ea970389a88eca5a65601460162d370a70018afe6f949a29dca91f3bb0", [:rebar3], [{:cowlib, "~> 1.0.2", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.3.2", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], [], "hexpm"},
   "distillery": {:hex, :distillery, "1.5.2", "eec18b2d37b55b0bcb670cf2bcf64228ed38ce8b046bb30a9b636a6f5a4c0080", [:mix], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.2.6", "b6da42b3831458d3ecc57314dff3051b080b9b2be88c2e5aa41cd642a5b044ed", [:mix], [], "hexpm"},
   "edeliver": {:hex, :edeliver, "1.4.6", "5927f3acffe0859e7812187fd604f70b5a74e599dd300f19774c0d7a16da09c9", [:mix], [{:distillery, ">= 1.0.0", [hex: :distillery, repo: "hexpm", optional: true]}], "hexpm"},
   "elixir_feed_parser": {:hex, :elixir_feed_parser, "2.0.0", "3a431d5980e095808ca1e2c00159fb7abe52a33cf54da64d4e60e3696a9c9ece", [:mix], [{:timex, "~> 3.1.13", [hex: :timex, repo: "hexpm", optional: false]}], "hexpm"},
   "file_system": {:hex, :file_system, "0.2.4", "f0bdda195c0e46e987333e986452ec523aed21d784189144f647c43eaf307064", [:mix], [], "hexpm"},
@@ -25,5 +25,4 @@
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], [], "hexpm"},
   "timex": {:hex, :timex, "3.3.0", "e0695aa0ddb37d460d93a2db34d332c2c95a40c27edf22fbfea22eb8910a9c8d", [:mix], [{:combine, "~> 0.10", [hex: :combine, repo: "hexpm", optional: false]}, {:gettext, "~> 0.10", [hex: :gettext, repo: "hexpm", optional: false]}, {:tzdata, "~> 0.1.8 or ~> 0.5", [hex: :tzdata, repo: "hexpm", optional: false]}], "hexpm"},
   "tzdata": {:hex, :tzdata, "0.5.17", "50793e3d85af49736701da1a040c415c97dc1caf6464112fd9bd18f425d3053b", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
-  "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], [], "hexpm"},
-}
+  "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], [], "hexpm"}}

--- a/test/elixir_talk_web/controllers/page_controller_test.exs
+++ b/test/elixir_talk_web/controllers/page_controller_test.exs
@@ -3,6 +3,6 @@ defmodule ElixirTalkWeb.PageControllerTest do
 
   test "GET /", %{conn: conn} do
     conn = get conn, "/"
-    assert html_response(conn, 200) =~ "Welcome to Phoenix!"
+    assert html_response(conn, 200) =~ "The ElixirTalk Podcast"
   end
 end

--- a/test/elixir_talk_web/views/page_view_test.exs
+++ b/test/elixir_talk_web/views/page_view_test.exs
@@ -1,3 +1,45 @@
 defmodule ElixirTalkWeb.PageViewTest do
   use ElixirTalkWeb.ConnCase, async: true
+
+  import ElixirTalkWeb.PageView
+
+  describe "markdown tests" do
+    test "a url is converted to a link" do
+      expected = "[http://foo.com](http://foo.com)"
+
+      result =
+        "http://foo.com"
+        |> replace_links
+
+      assert expected == result
+    end
+
+    test "multiple urls are converted to links" do
+      input = """
+** SHOW NOTES **
+* https://github.com/ElixirTalk/elixirtalk/issues/44
+* https://github.com/akoutmos/pharams
+* https://github.com/vic/params
+* https://github.com/jonasschmidt/ex_json_schema
+* https://github.com/bitwalker/libcluster
+* https://www.youtube.com/watch?v=L2_MUD16EIk
+"""
+
+      expected = """
+** SHOW NOTES **
+* [https://github.com/ElixirTalk/elixirtalk/issues/44](https://github.com/ElixirTalk/elixirtalk/issues/44)
+* [https://github.com/akoutmos/pharams](https://github.com/akoutmos/pharams)
+* [https://github.com/vic/params](https://github.com/vic/params)
+* [https://github.com/jonasschmidt/ex_json_schema](https://github.com/jonasschmidt/ex_json_schema)
+* [https://github.com/bitwalker/libcluster](https://github.com/bitwalker/libcluster)
+* [https://www.youtube.com/watch?v=L2_MUD16EIk](https://www.youtube.com/watch?v=L2_MUD16EIk)
+"""
+
+      result =
+        input
+        |> replace_links
+
+      assert expected == result
+    end
+  end
 end


### PR DESCRIPTION
This PR primarily adds an "episodes list" page.

### User Story
_As a_ consumer of the ElixirTalk podcase
_I want_ a listing of previous episodes and their details
_So that_ I can review show notes and content more easily

Additional changes:
* layout tweaks for the homepage
* addition of a markdown renderer for show-notes collected from SoundCloud
* addition of tests

Note: updating old show notes to conform to valid markdown would be worthwhile if/when this PR is merged.